### PR TITLE
Grammer refactoring

### DIFF
--- a/src/server/controllers/match.controller.js
+++ b/src/server/controllers/match.controller.js
@@ -26,14 +26,14 @@ export function requestMentoring(req, res, next) {
   let match = new Match(matchData);
 
   Match.findOne({ mentor_id: matchData.mentor_id, mentee_id: matchData.mentee_id }).exec()
-    .then(match => {
+    .then((match) => {
       if (!match) {
         return User.findOne({ _id: matchData.mentor_id }).exec();
       } else {
         throw new Error(matchCallback.ERR_MATCH_ALREADY_EXIST);
       }
     })
-    .then(mentor => {
+    .then((mentor) => {
       if (mentor) {
         // TODO: Confirm method whether send mail or send in-app message.
         mailingUtil.sendEmail(mentor.email, mailStrings.REQUEST_SUBJECT,
@@ -56,23 +56,23 @@ export function getMyActivity(req, res, next) {
   let activityData = {};
 
   findMenteeActivityByStatus(req.user._id, MATCH_STATUS.PENDING)
-    .then(pendingDoc => {
+    .then((pendingDoc) => {
       activityData['pending'] = pendingDoc;
       return findMenteeActivityByStatus(req.user._id, MATCH_STATUS.ACCEPTED);
     })
-    .then(acceptedDoc => {
+    .then((acceptedDoc) => {
       activityData['accepted'] = acceptedDoc;
       return findMenteeActivityByStatus(req.user._id, MATCH_STATUS.REJECTED);
     })
-    .then(rejectedDoc => {
+    .then((rejectedDoc) => {
       activityData['rejected'] = rejectedDoc;
       return findMentorActivity(req.user._id);
     })
-    .then(requestedDoc => {
+    .then((requestedDoc) => {
       activityData['requested'] = requestedDoc;
       res.status(200).json(activityData);
     })
-    .catch(err => {
+    .catch((err) => {
       res.status(400).json({ err_point: err.message, err: err.stack });
     });
 }

--- a/src/server/controllers/survey.controller.js
+++ b/src/server/controllers/survey.controller.js
@@ -14,7 +14,6 @@ const User = mongoose.model('user');
 
 // Get request
 export function getRequest(req, res, next) {
-  let surveyId;
   determineUser()
     .then((isSample) => {
       if (isSample) {

--- a/src/server/controllers/users.controller.js
+++ b/src/server/controllers/users.controller.js
@@ -607,7 +607,7 @@ export function getMentoringRequestStatus(req, res, next) {
     });
 }
 
-export function signout(req, res, next) {
+export function signOut(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
     .then((user) => {
       const index = user.deviceToken.indexOf(req.body.deviceToken);

--- a/src/server/controllers/users.controller.js
+++ b/src/server/controllers/users.controller.js
@@ -28,10 +28,10 @@ const FB_GRAPH_CRAWL_PARAMS = 'name,email,locale,timezone,education,work,locatio
 // Return all users.
 export function getAll(req, res, next) {
   User.find({}).exec()
-    .then(getAll => {
+    .then((getAll) => {
       res.status(200).json(getAll);
     })
-    .catch((err)=> {
+    .catch((err) => {
       res.status(400).json({ err_point: userCallback.ERR_MONGOOSE, err: err });
     });
 }
@@ -40,7 +40,7 @@ export function getAll(req, res, next) {
 export function getMentorList(req, res, next) {
   User.find({ _id: { $ne: req.user._id }, mentorMode: { $ne: false } })
     .sort({ stamp_login: -1 }).exec()
-    .then(mentorList => {
+    .then((mentorList) => {
       res.status(200).json(mentorList);
     })
     .catch((err) => {
@@ -51,7 +51,7 @@ export function getMentorList(req, res, next) {
 // Return my profile.
 export function getMyProfile(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
-    .then(myProfile => {
+    .then((myProfile) => {
       res.status(200).json(myProfile);
     })
     .catch((err) => {
@@ -64,17 +64,17 @@ export function getProfileById(req, res, next) {
   let userProfile = {};
 
   User.findOne({ _id: req.params._id }).exec()
-    .then(profile => {
+    .then((profile) => {
       userProfile = JSON.parse(JSON.stringify(profile));
       return Match.findOne({ mentor_id: userProfile._id, mentee_id: req.user._id }).exec();
     })
-    .then(matchAsMentee => {
+    .then((matchAsMentee) => {
       userProfile.relation = {};
       userProfile.relation.asMentee =
         matchAsMentee ? matchAsMentee.status : matchController.MATCH_STATUS.REJECTED;
       return Match.findOne({ mentor_id: req.user._id, mentee_id: userProfile._id }).exec();
     })
-    .then(matchAsMentor => {
+    .then((matchAsMentor) => {
       userProfile.relation.asMentor =
         matchAsMentor ? matchAsMentor.status : matchController.MATCH_STATUS.REJECTED;
       res.status(200).json(userProfile);
@@ -97,14 +97,14 @@ export function localSignUp(req, res, next) {
   };
 
   validateEmail(registrationData.email)
-    .then(result => {
+    .then((result) => {
       if (result) {
         return User.findOne({ email: registrationData.email }).exec();
       } else {
         throw new Error(userCallback.ERR_INVALID_EMAIL_FORMAT);
       }
     })
-    .then(existingUser => {
+    .then((existingUser) => {
       if (existingUser) {
         res.status(201).json({ msg: userCallback.ERR_EXISTING_EMAIL });
       } else {
@@ -112,10 +112,10 @@ export function localSignUp(req, res, next) {
         return User(registrationData).save();
       }
     })
-    .then(registeredUser => {
+    .then((registeredUser) => {
       return stampUser(registeredUser);
     })
-    .then(stampedUser => {
+    .then((stampedUser) => {
       if (stampedUser) {
         res.status(201).json({
           user: stampedUser,
@@ -125,7 +125,7 @@ export function localSignUp(req, res, next) {
         throw new Error(userCallback.ERR_FAIL_REGISTER);
       }
     })
-    .catch(err => {
+    .catch((err) => {
       res.status(400).json({ err_msg: err.message });
     });
 }
@@ -136,7 +136,7 @@ export function localSignIn(req, res, next) {
   let cryptoPassword = cipher.final('hex');
 
   User.findOne({ email: req.body.email }).exec()
-    .then(existingUser => {
+    .then((existingUser) => {
       if (!existingUser) {
         throw new Error(userCallback.ERR_USER_NOT_FOUND);
       } else {
@@ -161,7 +161,7 @@ export function localSignIn(req, res, next) {
         access_token: jwtUtil.createAccessToken(stampedUser),
       });
     })
-    .catch(function (err) {
+    .catch((err) => {
       res.status(400).json({ err_msg: err.message });
     });
 }
@@ -169,17 +169,17 @@ export function localSignIn(req, res, next) {
 export function requestSecretCode(req, res, next) {
   if (req.body.email) {
     User.findOne({ email: req.body.email }).exec()
-      .then(user => {
+      .then((user) => {
         if (!user) {
           throw new Error(userCallback.ERR_USER_NOT_FOUND);
         } else {
           return SecretCode.findOne({ email: req.body.email, isValid: true }).exec();
         }
       })
-      .then(validSecretCode => {
+      .then((validSecretCode) => {
         if (validSecretCode) {
           SecretCode.update({ _id: validSecretCode._id }, { $set: { isValid: false } }).exec()
-            .catch(err => {
+            .catch((err) => {
               throw new Error(userCallback.ERR_FAIL_SECRETCODE);
             });
         }
@@ -191,12 +191,12 @@ export function requestSecretCode(req, res, next) {
           = cipher.update(new Date().toISOString(), 'utf-8', 'hex') + cipher.final('hex');
         return secretCode.save();
       })
-      .then(secretCode => {
+      .then((secretCode) => {
         mailingUtil.sendEmail(req.body.email, mailStrings.RESETPW_SUBJECT,
           mailStrings.RESETPW_HTML, secretCode.secretCode);
         res.status(201).json({ secretCode: secretCode.secretCode });
       })
-      .catch(err => {
+      .catch((err) => {
         res.status(400).json({ err_msg: err.message });
       });
   } else {
@@ -210,12 +210,12 @@ export function resetPassword(req, res, next) {
   let crytoPassword = cipher.final('hex');
 
   User.findOne({ email: req.body.email }).exec()
-    .then(user => {
+    .then((user) => {
       if (!user) {
         throw new Error(userCallback.ERR_USER_NOT_FOUND);
       } else {
         SecretCode.findOne({ secretCode: req.body.secretCode }).exec()
-          .then(secretCode => {
+          .then((secretCode) => {
             if (secretCode.isValid) {
               return User.update(
                 { email: req.body.email },
@@ -225,15 +225,15 @@ export function resetPassword(req, res, next) {
               throw new Error(userCallback.ERR_INVALID_SECRETCODE);
             }
           })
-          .then(updatedUser => {
+          .then((updatedUser) => {
             res.status(200).json({ msg: userCallback.SUCCESS_RESET_PASSWORD });
           })
-          .catch(err => {
+          .catch((err) => {
             throw new Error(userCallback.ERR_FAIL_RESETPW);
           });
       }
     })
-    .catch(err => {
+    .catch((err) => {
       res.status(400).json({ err_point: err.message });
     });
 }
@@ -278,7 +278,7 @@ export function signIn(req, res, next) {
             });
         } else {
           stampDeviceToken(req.body.deviceToken, existingUser)
-            .then(user => stampUser(user))
+            .then((user) => stampUser(user))
             .then((stampedUser) => {
               res.status(200).json({
                 msg: userCallback.SUCCESS_SIGNIN,
@@ -379,7 +379,7 @@ function crawlByAccessTokenFacebook(accessToken) {
           resolve(result);
         }
       })
-      .catch(function (err) {
+      .catch((err) => {
         reject({ err_point: userCallback.ERR_INVALID_ACCESS_TOKEN });
       });
   });
@@ -387,7 +387,7 @@ function crawlByAccessTokenFacebook(accessToken) {
 
 export function editGeneralProfile(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
-    .then(user => {
+    .then((user) => {
       if (user) {
         return validateEmail(req.body.email);
       } else {
@@ -410,14 +410,14 @@ export function editGeneralProfile(req, res, next) {
         throw new Error(userCallback.ERR_INVALID_EMAIL_FORMAT);
       }
     })
-    .then(updateData => {
+    .then((updateData) => {
       if (updateData) {
         return setKey();
       } else {
         throw new Error(userCallback.ERR_MONGOOSE);
       }
     })
-    .then(keyData => {
+    .then((keyData) => {
       if (keyData) {
         if (req.body.image == null) {
           res.status(200).json({ msg: userCallback.SUCCESS_UPDATE_WITHOUT_IMAGE });
@@ -458,7 +458,7 @@ export function editGeneralProfile(req, res, next) {
         throw new Error(userCallback.ERR_AWS_KEY);
       }
     })
-    .catch(err => {
+    .catch((err) => {
       res.status(400).json(err);
     });
 }
@@ -547,7 +547,7 @@ export function editPersonality(req, res, next) {
 
 export function getCareerInfo(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
-    .then(user => {
+    .then((user) => {
       res.status(200).json(user.career);
     })
     .catch((err) => {
@@ -557,7 +557,7 @@ export function getCareerInfo(req, res, next) {
 
 export function getExpertiseInfo(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
-    .then(user => {
+    .then((user) => {
       res.status(200).json(user.expertise);
     })
     .catch((err) => {
@@ -567,7 +567,7 @@ export function getExpertiseInfo(req, res, next) {
 
 export function getPersonalityInfo(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
-    .then(user => {
+    .then((user) => {
       res.status(200).json(user.personality);
     })
     .catch((err) => {
@@ -582,7 +582,7 @@ export function setMentoringRequestStatus(req, res, next) {
         mentorMode: req.body.mentorMode,
       },
     }).exec()
-      .then(update => {
+      .then((update) => {
         res.status(200).json({ msg: userCallback.SUCCESS_UPDATE });
       })
       .catch((err) => {
@@ -595,7 +595,7 @@ export function setMentoringRequestStatus(req, res, next) {
 
 export function getMentoringRequestStatus(req, res, next) {
   User.findOne({ _id: req.user._id }).exec()
-    .then(user => {
+    .then((user) => {
       if (user.mentorMode == null) {
         res.status(200).json(true);
       } else {

--- a/src/server/controllers/users.controller.js
+++ b/src/server/controllers/users.controller.js
@@ -278,7 +278,7 @@ export function signIn(req, res, next) {
             });
         } else {
           stampDeviceToken(req.body.deviceToken, existingUser)
-            .then((user) => stampUser(user))
+            .then(user => stampUser(user))
             .then((stampedUser) => {
               res.status(200).json({
                 msg: userCallback.SUCCESS_SIGNIN,

--- a/src/server/routes/users.route.js
+++ b/src/server/routes/users.route.js
@@ -119,7 +119,7 @@ router.post('/signIn', user.signIn);
  *       "err_point": "Failed to sign out."
  *     }
  */
-router.post('/signOut', apiProtector, user.signout);
+router.post('/signOut', apiProtector, user.signOut);
 
 /**
  * @api {post} /users/secretCode Request a secret code

--- a/src/test/controllers/match.controller.test.js
+++ b/src/test/controllers/match.controller.test.js
@@ -11,13 +11,13 @@ const API_BASE_URL = 'http://localhost:8000';
 
 let matchData;
 
-describe('Test Match API', function () {
+describe('Test Match API', () => {
 
   describe('User B request mentoring to User A.', () => {
-    it('Sign up with valid Facebook user B.', done => {
+    it('Sign up with valid Facebook user B.', (done) => {
       rp({
         method: 'POST',
-        uri: `${API_BASE_URL}/users/signin`,
+        uri: `${API_BASE_URL}/users/signIn`,
         form: {
           access_token: userData.USER_B_FB_LONG_LIVED_ACCESS_TOKEN,
           platform_type: '1',
@@ -26,20 +26,19 @@ describe('Test Match API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(201);
-
           userData.USER_B_DATA = result.body.user;
           userData.USER_B_DATA.access_token = result.body.access_token;
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
     });
 
-    it('request mentoring to Invalid User.', done => {
+    it('request mentoring to Invalid User.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/match/request`,
@@ -54,11 +53,11 @@ describe('Test Match API', function () {
           access_token: userData.USER_B_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           should.fail();
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           done();
         });
@@ -83,17 +82,17 @@ describe('Test Match API', function () {
           access_token: userData.USER_B_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(201);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
     });
 
-    it('User B Retrieve activity page.', done => {
+    it('User B Retrieve activity page.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/match/activity`,
@@ -103,7 +102,7 @@ describe('Test Match API', function () {
           access_token: userData.USER_B_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           matchData = result.body;
           result.statusCode.should.equal(200);
           result.body.pending.length.should.equal(1);
@@ -112,7 +111,7 @@ describe('Test Match API', function () {
           result.body.requested.length.should.equal(0);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
@@ -120,10 +119,10 @@ describe('Test Match API', function () {
   });
 
   describe('User A accept mentoring from User B.', () => {
-    it('Sign up with User A.', done => {
+    it('Sign up with User A.', (done) => {
       rp({
         method: 'POST',
-        uri: `${API_BASE_URL}/users/signin`,
+        uri: `${API_BASE_URL}/users/signIn`,
         form: {
           access_token: userData.USER_A_FB_LONG_LIVED_ACCESS_TOKEN,
           platform_type: '1',
@@ -131,18 +130,18 @@ describe('Test Match API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           userData.USER_A_DATA = result.body.user;
           userData.USER_A_DATA.access_token = result.body.access_token;
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
     });
-    it('User A Retrieve activity page.', done => {
+    it('User A Retrieve activity page.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/match/activity`,
@@ -152,7 +151,7 @@ describe('Test Match API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           matchData = result.body;
           result.statusCode.should.equal(200);
           result.body.pending.length.should.equal(0);
@@ -161,12 +160,12 @@ describe('Test Match API', function () {
           result.body.requested.length.should.equal(1);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
     });
-    it('User A accept request from User B.', done => {
+    it('User A accept request from User B.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/match/response`,
@@ -180,11 +179,11 @@ describe('Test Match API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
@@ -193,7 +192,7 @@ describe('Test Match API', function () {
   });
 
   describe('User B check request status is changed.', () => {
-    it('Sign up with User B.', done => {
+    it('Sign up with User B.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/users/signIn`,
@@ -204,19 +203,19 @@ describe('Test Match API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           userData.USER_B_DATA = result.body.user;
           userData.USER_B_DATA.access_token = result.body.access_token;
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
     });
 
-    it('User B Retrieve activity page.', done => {
+    it('User B Retrieve activity page.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/match/activity`,
@@ -226,7 +225,7 @@ describe('Test Match API', function () {
           access_token: userData.USER_B_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           matchData = result.body;
           result.statusCode.should.equal(200);
           result.body.pending.length.should.equal(0);
@@ -235,7 +234,7 @@ describe('Test Match API', function () {
           result.body.requested.length.should.equal(0);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail(err);
           done();
         });
@@ -243,13 +242,13 @@ describe('Test Match API', function () {
   });
 
   describe('AnauthorizedAccess to API', () => {
-    it('request /activity without session coockie.', done => {
+    it('request /activity without session coockie.', (done) => {
       anauthorizedAccessTest('GET', `${API_BASE_URL}/match/activity`, done);
     });
-    it('request /request without session coockie.', done => {
+    it('request /request without session coockie.', (done) => {
       anauthorizedAccessTest('POST', `${API_BASE_URL}/match/request`, done);
     });
-    it('request /response without session coockie.', done => {
+    it('request /response without session coockie.', (done) => {
       anauthorizedAccessTest('POST', `${API_BASE_URL}/match/response`, done);
     });
   });
@@ -262,13 +261,12 @@ function anauthorizedAccessTest(method, uri, done) {
     resolveWithFullResponse: true,
     json: true,
   })
-    .then(function (result) {
+    .then((result) => {
       should.fail('status code is not 401');
       done();
     })
-    .catch(function (err) {
+    .catch((err) => {
       err.statusCode.should.equal(401);
       done();
     });
-
 }

--- a/src/test/controllers/survey.controller.test.js
+++ b/src/test/controllers/survey.controller.test.js
@@ -15,9 +15,9 @@ const Survey = mongoose.model('survey');
 
 const API_BASE_URL = 'http://localhost:8000/survey';
 
-describe('Test Survey API', function () {
-  describe('/create', function () {
-    it(': Save mentee survey.', function (done) {
+describe('Test Survey API', () => {
+  describe('/create', () => {
+    it(': Save mentee survey.', (done) => {
       let options = {
         method: 'POST',
         uri: `${API_BASE_URL}/create`,
@@ -33,11 +33,12 @@ describe('Test Survey API', function () {
           done();
         })
         .catch((err) => {
-
+          should.fail(err);
+          done();
         });
     });
 
-    it(': Save mentor survey.', function (done) {
+    it(': Save mentor survey.', (done) => {
       let options = {
         method: 'POST',
         uri: `${API_BASE_URL}/create`,
@@ -56,12 +57,13 @@ describe('Test Survey API', function () {
           done();
         })
         .catch((err) => {
-
+          should.fail(err);
+          done();
         });
     });
   });
 
-  describe('/request/:type', function () {
+  describe('/request/:type', () => {
     it('request /request/:type with Invalid parameter.', function (done) {
       this.timeout(4000);
       let options = {
@@ -78,10 +80,11 @@ describe('Test Survey API', function () {
       };
 
       rp(options)
-        .then(function (result) {
-
+        .then((result) => {
+          should.fail();
+          done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           err.error.err_point.should.equal(surveyCallback.ERR_INVALID_PARAMS);
           done();
@@ -104,13 +107,14 @@ describe('Test Survey API', function () {
       };
 
       rp(options)
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           result.body.survey_id.should.equal(menteeData.surveyA001_1.survey_id);
           done();
         })
-        .catch(function (err) {
-
+        .catch((err) => {
+          should.fail(err);
+          done();
         });
     });
 
@@ -130,19 +134,20 @@ describe('Test Survey API', function () {
       };
 
       rp(options)
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           result.body.survey_id.should.equal(mentorData.surveyB001_1.survey_id);
           done();
         })
-        .catch(function (err) {
-
+        .catch((err) => {
+          should.fail(err);
+          done();
         });
     });
   });
 
-  describe('/answer', function () {
-    it(': Save answer.', function (done) {
+  describe('/answer', () => {
+    it(': Save answer.', (done) => {
       let options = {
         method: 'POST',
         uri: `${API_BASE_URL}/answer`,
@@ -161,7 +166,8 @@ describe('Test Survey API', function () {
           done();
         })
         .catch((err) => {
-
+          should.fail(err);
+          done();
         });
     });
   });

--- a/src/test/controllers/users.controller.test.js
+++ b/src/test/controllers/users.controller.test.js
@@ -12,10 +12,10 @@ import userData from '../fixtures/userData';
 const API_BASE_URL = 'http://localhost:8000/users';
 let mentorMode = true;
 
-describe('Test User API', function () {
+describe('Test User API', () => {
 
-  describe('/signIn : FACEBOOK.', function () {
-    it(': Sign up invalid Facebook user.', done => {
+  describe('/signIn : FACEBOOK.', () => {
+    it(': Sign up invalid Facebook user.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/signIn`,
@@ -27,18 +27,18 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           should.fail('status code is not 400');
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           err.response.body.err_point.should.equal(userCallback.ERR_INVALID_ACCESS_TOKEN);
           done();
         });
     });
 
-    it(': Sign up with Invalid platform type.', done => {
+    it(': Sign up with Invalid platform type.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/signIn`,
@@ -50,18 +50,18 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           should.fail('status code is not 400');
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           err.response.body.err_point.should.equal(userCallback.ERR_INVALID_PLATFORM);
           done();
         });
     });
 
-    it(': Sign up valid Facebook user A.', done => {
+    it(': Sign up valid Facebook user A.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/signIn`,
@@ -73,20 +73,20 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(201);
           userData.USER_A_DATA = result.body.user;
           userData.USER_A_DATA.access_token = result.body.access_token;
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail();
           done();
 
         });
     });
 
-    it(': Sign in valid Facebook user A.', done => {
+    it(': Sign in valid Facebook user A.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/signIn`,
@@ -98,24 +98,24 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           result.body.msg.should.equal('Sign in success.');
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/all', function () {
-    it('request /all without access_token.', done => {
+  describe('/all', () => {
+    it('request /all without access_token.', (done) => {
       unauthorizedAccessTest(`${API_BASE_URL}/all`, done);
     });
 
-    it('request /all with access_token.', done => {
+    it('request /all with access_token.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/all`,
@@ -125,7 +125,7 @@ describe('Test User API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           let body = result.body;
           body[0]._id.should.equal(userData.USER_A_DATA._id);
@@ -133,19 +133,19 @@ describe('Test User API', function () {
           body[0].name.should.equal(userData.USER_A_DATA.name);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/me', function () {
-    it('request /me without access_token.', done => {
+  describe('/me', () => {
+    it('request /me without access_token.', (done) => {
       unauthorizedAccessTest(API_BASE_URL + '/me', done);
     });
 
-    it('request /me with access_token.', done => {
+    it('request /me with access_token.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/me`,
@@ -155,7 +155,7 @@ describe('Test User API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           let body = result.body;
           body._id.should.equal(userData.USER_A_DATA._id);
@@ -163,19 +163,19 @@ describe('Test User API', function () {
           body.name.should.equal(userData.USER_A_DATA.name);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/mentorList', function () {
-    it('request /mentorList without access_token.', done => {
+  describe('/mentorList', () => {
+    it('request /mentorList without access_token.', (done) => {
       unauthorizedAccessTest(API_BASE_URL + '/mentorList', done);
     });
 
-    it('request /mentorList with access_token.', done => {
+    it('request /mentorList with access_token.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/mentorList`,
@@ -185,25 +185,25 @@ describe('Test User API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           let body = result.body;
           body.length.should.equal(0);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/id/:id', function () {
-    it('request /id/:id without access_token.', done => {
+  describe('/id/:id', () => {
+    it('request /id/:id without access_token.', (done) => {
       unauthorizedAccessTest(`${API_BASE_URL}/id/${userData.USER_A_DATA._id}`, done);
     });
 
-    it('request /id/:id with access_token.', done => {
+    it('request /id/:id with access_token.', (done) => {
       rp({
         method: 'GET',
         uri: `${API_BASE_URL}/id/${userData.USER_A_DATA._id}`,
@@ -213,7 +213,7 @@ describe('Test User API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(function (result) {
+        .then((result) => {
           result.statusCode.should.equal(200);
           let body = result.body;
           body._id.should.equal(userData.USER_A_DATA._id);
@@ -223,15 +223,15 @@ describe('Test User API', function () {
           body.relation.asMentor.should.equal(0);
           done();
         })
-        .catch(function (err) {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/localSignUp', function () {
-    it(': Sign up as local login with invalid email format.', done => {
+  describe('/localSignUp', () => {
+    it(': Sign up as local login with invalid email format.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/localSignUp`,
@@ -239,17 +239,17 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           should.fail('status code should be 400');
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           done();
         });
     });
 
-    it(': Sign up as local login.', done => {
+    it(': Sign up as local login.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/localSignUp`,
@@ -257,18 +257,18 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           result.statusCode.should.equal(201);
           result.body.user.email.should.equal(userData.USER_E_DATA.email);
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
 
-    it(': Sign up as local login with existing email.', done => {
+    it(': Sign up as local login with existing email.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/localSignUp`,
@@ -279,19 +279,19 @@ describe('Test User API', function () {
           access_token: userData.USER_A_DATA.access_token,
         },
       })
-        .then(result => {
+        .then((result) => {
           result.statusCode.should.equal(201);
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/localSignIn', function () {
-    it(': Sign in as local login with not existing account.', done => {
+  describe('/localSignIn', () => {
+    it(': Sign in as local login with not existing account.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/localSignIn`,
@@ -300,17 +300,17 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           should.fail('status code should be 400');
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           done();
         });
     });
 
-    it(': Sign in as local login with existing account.', done => {
+    it(': Sign in as local login with existing account.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/localSignIn`,
@@ -319,19 +319,19 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           result.statusCode.should.equal(200);
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           should.fail();
           done();
         });
     });
   });
 
-  describe('/secretCode', function () {
-    it(': Request a new secret code with not existing account.', done => {
+  describe('/secretCode', () => {
+    it(': Request a new secret code with not existing account.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/secretCode`,
@@ -342,17 +342,17 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           should.fail('status code should be 400');
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           err.statusCode.should.equal(400);
           done();
         });
     });
 
-    it(': Request a new secret code with existing account.', done => {
+    it(': Request a new secret code with existing account.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/secretCode`,
@@ -363,12 +363,12 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           result.statusCode.should.equal(201);
           userData.SECRET_CODE = result.body.secretCode;
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           should.fail();
           done();
         });
@@ -376,7 +376,7 @@ describe('Test User API', function () {
   });
 
   describe('/resetPassword', () => {
-    it(': Reset password with not existing user.', done => {
+    it(': Reset password with not existing user.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/resetPassword`,
@@ -395,7 +395,7 @@ describe('Test User API', function () {
         });
     });
 
-    it(': Reset password with existing user.', done => {
+    it(': Reset password with existing user.', (done) => {
       rp({
         method: 'POST',
         uri: `${API_BASE_URL}/resetPassword`,
@@ -408,11 +408,11 @@ describe('Test User API', function () {
         resolveWithFullResponse: true,
         json: true,
       })
-        .then(result => {
+        .then((result) => {
           result.statusCode.should.equal(200);
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           should.fail();
           done();
         });
@@ -420,8 +420,8 @@ describe('Test User API', function () {
   });
 });
 
-describe('/editCareer', function () {
-  it('request /editCareer with session cookie.', done => {
+describe('/editCareer', () => {
+  it('request /editCareer with session cookie.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/editCareer`,
@@ -432,20 +432,20 @@ describe('/editCareer', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         result.body.msg.should.equal(userCallback.SUCCESS_EDIT);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/editExpertise', function () {
-  it('request /editExpertise with session cookie.', done => {
+describe('/editExpertise', () => {
+  it('request /editExpertise with session cookie.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/editExpertise`,
@@ -456,20 +456,20 @@ describe('/editExpertise', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         result.body.msg.should.equal(userCallback.SUCCESS_EDIT);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/editPersonality', function () {
-  it('request /editPersonality with session cookie.', done => {
+describe('/editPersonality', () => {
+  it('request /editPersonality with session cookie.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/editPersonality`,
@@ -480,20 +480,20 @@ describe('/editPersonality', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         result.body.msg.should.equal(userCallback.SUCCESS_EDIT);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/career', function () {
-  it('request /career with session cookie.', done => {
+describe('/career', () => {
+  it('request /career with session cookie.', (done) => {
     rp({
       method: 'GET',
       uri: `${API_BASE_URL}/career`,
@@ -503,7 +503,7 @@ describe('/career', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         const body = result.body[0];
         const data = signupData.career_data.career[0];
@@ -513,15 +513,15 @@ describe('/career', function () {
         body.education_background.should.equal(data.education_background);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/expertise', function () {
-  it('request /expertise with session cookie.', done => {
+describe('/expertise', () => {
+  it('request /expertise with session cookie.', (done) => {
     rp({
       method: 'GET',
       uri: `${API_BASE_URL}/expertise`,
@@ -531,22 +531,22 @@ describe('/expertise', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         const body = result.body;
         const data = signupData.expertise_data.expertise;
         body[0].select.should.equal(data[0].select);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/personality', function () {
-  it('request /personality with session cookie.', done => {
+describe('/personality', () => {
+  it('request /personality with session cookie.', (done) => {
     rp({
       method: 'GET',
       uri: `${API_BASE_URL}/personality`,
@@ -556,7 +556,7 @@ describe('/personality', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         const body = result.body;
         const data = signupData.personality_data.personality;
@@ -564,15 +564,15 @@ describe('/personality', function () {
         body[0].score.should.equal(data[0].score);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/setRequestStatus', function () {
-  it('request /setRequestStatus with invalid parameter.', done => {
+describe('/setRequestStatus', () => {
+  it('request /setRequestStatus with invalid parameter.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/editMentorMode`,
@@ -583,18 +583,18 @@ describe('/setRequestStatus', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         should.fail();
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         err.statusCode.should.equal(400);
         err.response.body.err_point.should.equal(userCallback.ERR_INVALID_PARAMS);
         done();
       });
   });
 
-  it('request /setRequestStatus with valid parameter.', done => {
+  it('request /setRequestStatus with valid parameter.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/editMentorMode`,
@@ -605,20 +605,20 @@ describe('/setRequestStatus', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         result.body.msg.should.equal(userCallback.SUCCESS_UPDATE);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/getRequestStatus', function () {
-  it('request /mentorMode with session cookie.', done => {
+describe('/getRequestStatus', () => {
+  it('request /mentorMode with session cookie.', (done) => {
     rp({
       method: 'GET',
       uri: `${API_BASE_URL}/mentorMode`,
@@ -628,20 +628,20 @@ describe('/getRequestStatus', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         result.body.result.should.equal(mentorMode);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
 });
 
-describe('/accessToken', function () {
-  it('request /accessToken to check validation of access token.', done => {
+describe('/accessToken', () => {
+  it('request /accessToken to check validation of access token.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/accessToken`,
@@ -651,16 +651,16 @@ describe('/accessToken', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
-  it('request /accessToken to check validation of access token.', done => {
+  it('request /accessToken to check validation of access token.', (done) => {
     rp({
       method: 'POST',
       uri: `${API_BASE_URL}/accessToken`,
@@ -670,17 +670,17 @@ describe('/accessToken', function () {
         access_token: `${userData.USER_A_DATA.access_token}abcd`,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         should.fail();
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         err.statusCode.should.equal(401);
         done();
       });
   });
 
-  it('request /accessToken to update access token.', done => {
+  it('request /accessToken to update access token.', (done) => {
     rp({
       method: 'PUT',
       uri: `${API_BASE_URL}/accessToken`,
@@ -690,16 +690,16 @@ describe('/accessToken', function () {
         access_token: userData.USER_A_DATA.access_token,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         result.statusCode.should.equal(200);
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         should.fail();
         done();
       });
   });
-  it('request /accessToken to update access token.', done => {
+  it('request /accessToken to update access token.', (done) => {
     rp({
       method: 'PUT',
       uri: `${API_BASE_URL}/accessToken`,
@@ -709,11 +709,11 @@ describe('/accessToken', function () {
         access_token: `${userData.USER_A_DATA.access_token}abcd`,
       },
     })
-      .then(function (result) {
+      .then((result) => {
         should.fail();
         done();
       })
-      .catch(function (err) {
+      .catch((err) => {
         err.statusCode.should.equal(401);
         done();
       });
@@ -727,11 +727,11 @@ function unauthorizedAccessTest(uri, done) {
     resolveWithFullResponse: true,
     json: true,
   })
-    .then(function (result) {
+    .then((result) => {
       should.fail('status code is not 401');
       done();
     })
-    .catch(function (err) {
+    .catch((err) = {
       err.statusCode.should.equal(401);
       done();
     });

--- a/src/test/controllers/users.controller.test.js
+++ b/src/test/controllers/users.controller.test.js
@@ -731,7 +731,7 @@ function unauthorizedAccessTest(uri, done) {
       should.fail('status code is not 401');
       done();
     })
-    .catch((err) = {
+    .catch((err) => {
       err.statusCode.should.equal(401);
       done();
     });


### PR DESCRIPTION
It was a nogada, but I made it :tada:

Not a big change, but just unifying grammar.

Re-notify: 
There's a issue about setting Timeout that Yangwoo found.
If we use Timeout function for any needed reason, ES6 grammar, especially expressing function as arrow(```=>```), does not work. So I remained few functions as ES5.
It's a public issue with ES6.

@SarahhhC @MechanicKim 